### PR TITLE
fix: increase max sample ID length

### DIFF
--- a/src/samshee/validation.py
+++ b/src/samshee/validation.py
@@ -199,7 +199,7 @@ illuminasamplesheetv2schema = {
                     "Sample_ID": {
                         "type": "string",
                         "pattern": r"^[a-zA-Z0-9\-_]+$",
-                        "maxLength": 40,
+                        "maxLength": 100,
                         "description": "The ID of the sample. Separate each identifier with a dash or underscore.",
                         "examples": ["Sample1-DQB1-022515"],
                     },


### PR DESCRIPTION
According to [illumina docs](https://www.tst-web.illumina.com/content/dam/illumina-marketing/documents/products/technotes/sequencing-sheet-format-specifications-technical-note-970-2017-004.pdf), SampleSheet v2 "Sample_ID length is limited to 100 characters maximum."